### PR TITLE
DESIGN polish: square cards, hover zoom+blur, page margins

### DIFF
--- a/design/index.html
+++ b/design/index.html
@@ -47,14 +47,14 @@
     <button class="filter-tag active" data-filter="all">全部</button>
     <button class="filter-tag" data-filter="品牌識別">品牌識別</button>
     <button class="filter-tag" data-filter="主視覺">主視覺</button>
-    <button class="filter-tag" data-filter="出版物">出版物</button>
     <button class="filter-tag" data-filter="周邊">周邊</button>
     <button class="filter-tag" data-filter="平面圖文">平面圖文</button>
     <button class="filter-tag" data-filter="影片">影片</button>
   </div>
 
   <div class="brand-grid cols-3">
-    <a href="yuntech-xd/index.html" class="brand-card" data-tag="主視覺" style="background-image:url('yuntech-xd/img/畢籌作品集_01.jpg');background-size:cover;background-position:center;">
+    <a href="yuntech-xd/index.html" class="brand-card has-img" data-tag="主視覺">
+      <div class="brand-card-img" style="background-image:url('/design/yuntech-xd/img/畢籌作品集_01.jpg');"></div>
       <span class="bc-tag">主視覺</span>
       <div class="hover-overlay">
         <div class="hover-title">(XD)</div>

--- a/style.css
+++ b/style.css
@@ -17,7 +17,7 @@
 body {
   font-family: 'Inter', -apple-system, "Helvetica Neue", sans-serif;
   letter-spacing: -0.05cap;
-  background: #FAFAFA;
+  background: #F3F2F3;
   color: var(--dark);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -61,6 +61,8 @@ body.inner-page .nav {
 }
 body.inner-page main {
   padding-top: 87px;
+  max-width: 960px;
+  margin: 0 auto;
 }
 .nav-logo {
   font-size: 14px;
@@ -555,20 +557,26 @@ body.inner-page main {
   transition: border-color 0.3s;
 }
 .brand-card:hover { border-color: var(--accent); }
+.brand-card { isolation: isolate; }
 .brand-card .img-label { font-size: 11px; color: var(--gray); }
 .brand-card .hover-overlay {
   position: absolute;
   inset: 0;
-  background: rgba(46, 91, 255, 0.85);
+  background: rgba(46, 91, 255, 0.75);
   color: #fff;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  text-align: center;
+  padding: 48px 40px;
   opacity: 0;
-  transition: opacity 0.4s;
+  transition: opacity 0.5s ease-out;
 }
-.brand-card:hover .hover-overlay { opacity: 1; }
+.brand-card:hover .hover-overlay {
+  opacity: 1;
+  transition: opacity 0.3s ease-in;
+}
 .brand-card .hover-title { font-size: 28px; font-weight: 900; margin-bottom: 8px; }
 .brand-card .hover-meta { font-size: 11px; opacity: 0.8; letter-spacing: 0.15em; text-transform: uppercase; }
 .brand-card .bc-tag {
@@ -583,10 +591,26 @@ body.inner-page main {
   transition: opacity 0.3s;
 }
 .brand-card:hover .bc-tag { opacity: 0; }
+.brand-card-img {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  transition: transform 0.5s ease-out, filter 0.5s ease-out;
+  transform-origin: center center;
+  transform: scale(1);
+  filter: blur(0);
+  will-change: transform, filter;
+}
+.brand-card.has-img:hover .brand-card-img {
+  transform: scale(1.25);
+  filter: blur(5px);
+  transition: transform 0.3s ease-in, filter 0.3s ease-in;
+}
 
 /* DESIGN page: 3-col grid + tighter cards for 15-item layout */
 .brand-grid.cols-3 { grid-template-columns: 1fr 1fr 1fr; }
-.brand-grid.cols-3 .brand-card { aspect-ratio: 4/5; }
+.brand-grid.cols-3 .brand-card { aspect-ratio: 1/1; }
 @media (max-width: 720px) {
   .brand-grid.cols-3 { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
## Summary
- Inner pages 加 max-width 960px 置中（header/footer 維持滿版）
- DESIGN 卡片改 1:1 方形 / 3-col grid
- (XD) 卡片 hover 效果：圖 scale(1.25) + blur(5px)，藍色 75% overlay 淡入
- 非對稱緩動：進入 0.3s ease-in / 離開 0.5s ease-out
- 移除「出版物」篩選（無作品使用）
- Body bg #FAFAFA → #F3F2F3
- Hover overlay padding 加大（48/40），文字置中
- (XD) 圖片路徑改絕對路徑（避免 /design/ 無 trailing slash 時 404）
- GPU layer 提示防止首次 hover 閃爍

## Test plan
- [x] 本機預覽：圖片正常顯示
- [x] hover overlay 淡入淡出 + 圖縮放/模糊
- [ ] 合併後線上 weiimg.com/design/ 確認無異常

🤖 Generated with [Claude Code](https://claude.com/claude-code)